### PR TITLE
fix(playground): make browser playground boot in repo dev mode

### DIFF
--- a/packages/playground/backend/server.ts
+++ b/packages/playground/backend/server.ts
@@ -21,10 +21,14 @@ import { fileURLToPath } from "node:url";
 const DEFAULT_PORT = Number(process.env.PORT ?? "4173");
 const playgroundDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const secureExecDir = resolve(playgroundDir, "../secure-exec");
+const secureExecCoreDir = resolve(playgroundDir, "../secure-exec-core");
+const secureExecBrowserDir = resolve(playgroundDir, "../secure-exec-browser");
 
 /* Map URL prefixes to filesystem directories outside playgroundDir */
 const PATH_ALIASES: Array<{ prefix: string; dir: string }> = [
 	{ prefix: "/secure-exec/", dir: secureExecDir },
+	{ prefix: "/secure-exec-core/", dir: secureExecCoreDir },
+	{ prefix: "/secure-exec-browser/", dir: secureExecBrowserDir },
 ];
 
 const mimeTypes = new Map<string, string>([

--- a/packages/playground/frontend/index.html
+++ b/packages/playground/frontend/index.html
@@ -9,6 +9,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <script defer src="/vendor/typescript.js"></script>
     <script defer src="/vendor/monaco/vs/loader.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "secure-exec/browser": "/secure-exec/dist/browser-runtime.js",
+          "@secure-exec/core": "/secure-exec-core/dist/index.js",
+          "@secure-exec/browser": "/secure-exec-browser/dist/index.js"
+        }
+      }
+    </script>
     <style>
       :root {
         color-scheme: dark;

--- a/packages/playground/scripts/build-worker.ts
+++ b/packages/playground/scripts/build-worker.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 
 const playgroundDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const workerSourcePath = resolve(playgroundDir, "../secure-exec/src/browser/worker.ts");
+const workerSourcePath = resolve(playgroundDir, "../secure-exec-browser/src/worker.ts");
 const workerSourceDir = dirname(workerSourcePath);
 const workerOutputPath = resolve(playgroundDir, "secure-exec-worker.js");
 const appSourcePath = resolve(playgroundDir, "frontend/app.ts");
@@ -12,10 +12,14 @@ const appOutputPath = resolve(playgroundDir, "dist/app.js");
 
 const BRIDGE_IMPORT_BLOCK = `\tlet bridgeModule: Record<string, unknown>;
 \ttry {
-\t\tbridgeModule = await dynamicImportModule("../bridge/index.js");
+\t\tbridgeModule = await dynamicImportModule("@secure-exec/core/internal/bridge");
 \t} catch {
-\t\t// Vite browser tests execute source files directly, so \`.ts\` fallback is required.
-\t\tbridgeModule = await dynamicImportModule("../bridge/index.ts");
+\t\t// Vite browser tests may need source fallback.
+\t\ttry {
+\t\t\tbridgeModule = await dynamicImportModule("@secure-exec/core/internal/bridge");
+\t\t} catch {
+\t\t\tthrow new Error("Failed to load bridge module from @secure-exec/core");
+\t\t}
 \t}`;
 
 async function writeGeneratedBundle(outputPath: string, sourcePath: string): Promise<void> {
@@ -27,10 +31,10 @@ async function buildWorkerBundle(): Promise<void> {
 	const originalSource = await readFile(workerSourcePath, "utf8");
 	const patchedSource = originalSource
 		.replace(
-			'import { mkdir } from "../fs-helpers.js";',
-			'import { mkdir } from "../fs-helpers.js";\nimport * as browserWorkerBridgeModule from "../bridge/index.ts";',
+			'import { validatePermissionSource } from "./permission-validation.js";',
+			'import { validatePermissionSource } from "./permission-validation.js";\nimport importedBridgeModule from "@secure-exec/core/internal/bridge";',
 		)
-		.replace(BRIDGE_IMPORT_BLOCK, "\tconst bridgeModule = browserWorkerBridgeModule;");
+		.replace(BRIDGE_IMPORT_BLOCK, "\tconst bridgeModule = { default: importedBridgeModule };");
 
 	await build({
 		bundle: true,


### PR DESCRIPTION
## Summary

Fix the browser playground so the documented local dev flow works again.

This updates the playground dev server and worker bundling so
`pnpm -C packages/playground dev` can boot the browser runtime without
failing on unresolved workspace imports or runtime bridge loading.

## Problem

The playground README says it can be started directly from the repo, but the
page failed to boot in browser dev mode:

- the browser could not resolve `secure-exec/browser`
- the generated playground worker still tried to dynamically import
  `@secure-exec/core/internal/bridge`
- the worker bundling script pointed at the proxy worker entry instead of the
  actual browser worker implementation

That left the playground stuck with errors like:

- `Failed to resolve module specifier "secure-exec/browser"`
- `Failed to load bridge module from @secure-exec/core`

## Changes

- add local static path aliases for `@secure-exec/core` and `@secure-exec/browser`
  assets in the playground dev server
- add an import map in the playground HTML so browser ESM can resolve the
  workspace packages from local `dist/` output
- point the playground worker bundler at `packages/secure-exec-browser/src/worker.ts`
  instead of the proxy worker entry
- patch the generated playground worker to statically include the bridge module
  instead of leaving a runtime dynamic import behind

## Why

The playground is intended to be runnable directly from this repository.
These changes make the repo-local dev path match the documented setup and keep
the worker self-contained enough for browser dev mode.

## Validation

Attempted:
- `pnpm -C packages/playground build:assets`

Note:
- in my sandbox this is currently blocked by `tsx` IPC socket permissions
  (`listen EPERM ... tsx-*.pipe`), so I could not complete end-to-end
  verification from the agent environment.
